### PR TITLE
Fix code scanning alert no. 1: Use of a predictable seed in a secure random number generator

### DIFF
--- a/CamBench_Cap/src/main/java/org/cambench/cap/basic/insecurerandom/InsecureRandom2.java
+++ b/CamBench_Cap/src/main/java/org/cambench/cap/basic/insecurerandom/InsecureRandom2.java
@@ -32,7 +32,6 @@ public class InsecureRandom2 {
 
         byte[] ivBytes = new byte[16];
         SecureRandom secureRandom = new SecureRandom();
-        secureRandom.setSeed(123);
         secureRandom.nextBytes(ivBytes);
 
         IvParameterSpec iv = new IvParameterSpec(ivBytes);


### PR DESCRIPTION
Fixes [https://github.com/mraashish/CamBench/security/code-scanning/1](https://github.com/mraashish/CamBench/security/code-scanning/1)

To fix the problem, we need to ensure that the `SecureRandom` instance is seeded securely. The best way to do this is to allow the `SecureRandom` instance to seed itself, which it will do in a secure manner by default. This involves removing the line that sets the seed with a constant value.

- Remove the line that sets the seed with a constant value (`secureRandom.setSeed(123);`).
- Ensure that the `SecureRandom` instance is used without manually setting a seed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
